### PR TITLE
Fixing canvas version in order to get macOS build running

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Nadav Ivgi",
   "license": "Public domain or CC0",
   "dependencies": {
-    "canvas": "^1.1.3"
+    "canvas": "^2.6.0"
   },
   "browser": {
     "./canvas.js": "./canvas.browser.js"


### PR DESCRIPTION
MacOS build is failed because of outdated canvas version. This PR updates dependency solving the problem